### PR TITLE
Exact time ticks

### DIFF
--- a/ui-state-trail.html
+++ b/ui-state-trail.html
@@ -54,8 +54,8 @@ SOFTWARE.
     <input type='number' id='node-input-tickmarks' min='2' max='25' value='4' size='1' style='width:47px' >
 </div>
 <div class='form-row' id='node-input-exact-time-ticks'>
-    <label for='node-input-exact-ticks'><i class='icon-tag'></i> Exact Time Ticks</label>
-    <input type="checkbox" id="node-input-exact-ticks" 
+    <label for='node-input-exactticks'><i class='icon-tag'></i> Exact Time Ticks</label>
+    <input type="checkbox" id="node-input-exactticks" 
             style="display:inline-block; width:auto; vertical-align:baseline; 
             margin-right:5px;margin-left:5px;">Marks the state changes with exact time ticks (ticks count will be ignored)
 </div>

--- a/ui-state-trail.html
+++ b/ui-state-trail.html
@@ -53,6 +53,12 @@ SOFTWARE.
     <label for='node-input-tickmarks' style='width:33px'>Ticks</label>
     <input type='number' id='node-input-tickmarks' min='2' max='25' value='4' size='1' style='width:47px' >
 </div>
+<div class='form-row' id='node-input-exact-time-ticks'>
+    <label for='node-input-exact-ticks'><i class='icon-tag'></i> Exact Time Ticks</label>
+    <input type="checkbox" id="node-input-exact-ticks" 
+            style="display:inline-block; width:auto; vertical-align:baseline; 
+            margin-right:5px;margin-left:5px;">Marks the state changes with exact time ticks (ticks count will be ignored)
+</div>
 <div class="form-row" style="margin-bottom:0;">
     <label><i class="fa fa-list"></i> States:</label>
     <span id="configError" style="color:#DD0000"><b>All Values must be unique.</b></span>
@@ -78,7 +84,7 @@ SOFTWARE.
             margin-right:5px;margin-left:5px;">Use persistable storage if available
 </div>
 <div class='form-row' id='node-input-performance'>
-    <label for='node-input-persist'><i class='icon-tag'></i> Performance</label>
+    <label for='node-input-combine'><i class='icon-tag'></i> Performance</label>
     <input type="checkbox" checked id="node-input-combine" 
             style="display:inline-block; width:auto; vertical-align:baseline; 
             margin-right:5px;margin-left:5px;">Combine similar states
@@ -463,8 +469,8 @@ SOFTWARE.
         
 
     <h2>Time format and Ticks</h2>
-    <p>Choose format of time and count of tick marks.
-     
+    <p>Choose format of time and count of tick marks. If the "Exact Ticks" is selected, the state change will be marked with the exact time and the ticks count will be ignored.
+    
     <h2>States</h2>
     <p>Configure at least 2 states. Type of state can be <code>string</code>, <code>number</code> or <code>boolean</code>.  
         States can be configured with mixing the types. States <code>true</code> (boolean) and <code>"true"</code> (string) treated as different states. 

--- a/ui-state-trail.html
+++ b/ui-state-trail.html
@@ -146,6 +146,7 @@ SOFTWARE.
             periodLimitUnit: {value: '3600',required: true},
             timeformat: {value: 'HH:mm:ss'},
             tickmarks: {val: 4, required: true},
+            exactticks: {val: false, required: true},
             persist: {val: false, required: true},
             legend: {
                 value: 1,
@@ -197,6 +198,10 @@ SOFTWARE.
             if (this.tickmarks === undefined) {
                 this.tickmarks = 4;
                 $('#node-input-tickmarks').val('4');
+            }
+
+            if (this.exactticks === undefined) {
+                $('#node-input-exactticks').prop('checked', false);
             }
 
             if (this.legend === undefined) {

--- a/ui-state-trail.js
+++ b/ui-state-trail.js
@@ -572,7 +572,7 @@ module.exports = function (RED) {
 					var po
 					var t
 					var vis
-					if (config.exact-ticks){
+					if (config.exactticks){
 						for (let i = 0; i < storage.length; i++) {
 							t = storage[i].timestamp						
 							po = getPosition(t, config.insidemin, config.max)							

--- a/ui-state-trail.js
+++ b/ui-state-trail.js
@@ -572,20 +572,35 @@ module.exports = function (RED) {
 					var po
 					var t
 					var vis
-					var total = config.max - config.insidemin
-					var step = (total / (config.tickmarks - 1))					
-					for (let i = 0; i < config.tickmarks; i++) {
-						t = storage[1].timestamp + (step * i)						
-						po = getPosition(t, config.insidemin, config.max)							
-						vis = ret.find(el => el.x == po) ? "hidden" : "visible" 				
-						o = {
-							x: po,
-							v: formatTime(t),
-							id: i,
-							vis:vis
-						}
-						ret.push(o)
-					}					
+					if (config.exact-ticks){
+						for (let i = 0; i < storage.length; i++) {
+							t = storage[i].timestamp						
+							po = getPosition(t, config.insidemin, config.max)							
+							vis = ret.find(el => el.x == po) ? "hidden" : "visible" 				
+							o = {
+								x: po,
+								v: formatTime(t),
+								id: i,
+								vis:vis
+							}
+							ret.push(o)
+						}	
+					} else {
+						var total = config.max - config.insidemin
+						var step = (total / (config.tickmarks - 1))	
+						for (let i = 0; i < config.tickmarks; i++) {
+							t = storage[1].timestamp + (step * i)						
+							po = getPosition(t, config.insidemin, config.max)							
+							vis = ret.find(el => el.x == po) ? "hidden" : "visible" 				
+							o = {
+								x: po,
+								v: formatTime(t),
+								id: i,
+								vis:vis
+							}
+							ret.push(o)
+						}		
+					}
 					return ret
 				}
 


### PR DESCRIPTION
Hi,
I added an option to display the time ticks on the exact spot of a status change.
![exact-ticks](https://user-images.githubusercontent.com/7968564/173819544-3da490c2-0f7a-4346-bb8f-5299e4a6b716.png)

This feature is useful when, as in my case, someone need to keep track of few changes on a long period of time (like 24 hours).

Also correct what seems to be a little bug in the config HTML: the attribute `for` of the `node-input-performance` label tag should be `node-input-combine`, and not `node-input-persist` (this created a sort of misbehavior where clicking the `Performance` text switch the Data Storage property).

Hope that all is ok (this is my first approach to node-red coding).